### PR TITLE
make the dictionary db as a real singleton

### DIFF
--- a/wrapcache/adapter/MemoryAdapter.py
+++ b/wrapcache/adapter/MemoryAdapter.py
@@ -13,7 +13,7 @@ class MemoryAdapter(BaseAdapter):
 	'''
 	def __init__(self, timeout = -1):
 		super(MemoryAdapter, self).__init__(timeout = timeout)
-		if not MemoryAdapter.db:
+		if MemoryAdapter.db is None:
 			MemoryAdapter.db = {}
 
 	def get(self, key):
@@ -47,25 +47,32 @@ if __name__ == '__main__':
 			self.test_class = MemoryAdapter(timeout = 3)
 		def tearDown(self):
 			pass
-		
+
+		def test_init_db_with_singleton(self):
+			pre_db = self.test_class.db
+			# get a new instance without cache
+			new_adapter = MemoryAdapter(timeout = 1)
+			cur_db = new_adapter.db
+			self.assertIs(pre_db, cur_db)
+
 		def test_memory_adapter(self):
 			key = 'test_key_1'
 			value = str(time.time())
-			
+
 			#test set / get
 			self.test_class.set(key, value)
 			self.assertEqual(self.test_class.get(key), value)
 			time.sleep(4)
 			self.assertRaises(CacheExpiredException, self.test_class.get, key)
-			
+
 			#test remove
 			self.test_class.set(key, value)
 			self.test_class.remove(key)
 			self.assertRaises(CacheExpiredException, self.test_class.get, key)
-			
+
 			#test flush
 			self.test_class.set(key, value)
 			self.test_class.flush()
 			self.assertRaises(CacheExpiredException, self.test_class.get, key)
-			
+
 	unittest.main()

--- a/wrapcache/adapter/MemoryAdapter.py
+++ b/wrapcache/adapter/MemoryAdapter.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
 			# get a new instance without cache
 			new_adapter = MemoryAdapter(timeout = 1)
 			cur_db = new_adapter.db
-			self.assertIs(pre_db, cur_db)
+			self.assertEqual(id(pre_db), id(cur_db))
 
 		def test_memory_adapter(self):
 			key = 'test_key_1'


### PR DESCRIPTION
when get a new instance of a MemoryAdapter which have no data in cache db,
it will create a new dictionary. 'cause empty {} is a False value.

fix it and add the test case.