### PR TITLE
[fix] fix unexpected output from functions with same name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ target/
 MANIFEST
 README
 test.py
+.idea/

--- a/wrapcache/__init__.py
+++ b/wrapcache/__init__.py
@@ -20,12 +20,17 @@ A python Function / Method OUTPUT cache system base on function Decorators.
 
 Auto cache the Funtion OUTPUT for sometime.
 '''
+def _from_file(function):
+    if hasattr(function, '__code__'):
+        return function.__code__.co_filename
+    else:
+        return ''
 
 def _wrap_key(function, args, kws):
 	'''
 	get the key from the function input.
 	'''
-	return hashlib.md5(pickle.dumps((function.__name__, args, kws))).hexdigest()
+	return hashlib.md5(pickle.dumps((_from_file(function) + function.__name__, args, kws))).hexdigest()
 
 def keyof(function, *args, **kws):
 	'''


### PR DESCRIPTION
尝试修复不同文件下相同名字的函数会混淆结果的问题。